### PR TITLE
Modificaciones del setup.py para que sea compatible con pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     install_requires = [
     'pyparsing',
     ],
-    version=__import__('plyse').__version__,
+    version=1.0.1,
     url='https://github.com/sebastiandev/plyse',
     author='Sebastian Packmann',
     author_email='devsebas@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -36,4 +36,10 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
     ],
+    install_requires = [
+    'pyparsing',
+    ],
+    setup_requires = [
+    'pyparsing',
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -36,10 +36,10 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
     ],
-    install_requires = [
+    setup_requires = [
     'pyparsing',
     ],
-    setup_requires = [
+    install_requires = [
     'pyparsing',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     install_requires = [
     'pyparsing',
     ],
-    version=1.0.1,
+    version='1.0.1',
     url='https://github.com/sebastiandev/plyse',
     author='Sebastian Packmann',
     author_email='devsebas@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,12 @@ setup(
     author_email='devsebas@gmail.com',
     description=('A fully extensible query parser inspired on the lucene and gmail sintax'),
     license='MIT',
+    setup_requires = [
+    'pyparsing',
+    ],
+    install_requires = [
+    'pyparsing',
+    ],
     package_dir={
         'plyse': 'plyse',
         'plyse.expressions': 'plyse/expressions',
@@ -35,11 +41,5 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
-    ],
-    setup_requires = [
-    'pyparsing',
-    ],
-    install_requires = [
-    'pyparsing',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -4,18 +4,18 @@ from setuptools import setup
 # Dynamically calculate the version based on plyse.VERSION.
 setup(
     name='plyse',
-    version=__import__('plyse').__version__,
-    url='https://github.com/sebastiandev/plyse',
-    author='Sebastian Packmann',
-    author_email='devsebas@gmail.com',
-    description=('A fully extensible query parser inspired on the lucene and gmail sintax'),
-    license='MIT',
     setup_requires = [
     'pyparsing',
     ],
     install_requires = [
     'pyparsing',
     ],
+    version=__import__('plyse').__version__,
+    url='https://github.com/sebastiandev/plyse',
+    author='Sebastian Packmann',
+    author_email='devsebas@gmail.com',
+    description=('A fully extensible query parser inspired on the lucene and gmail sintax'),
+    license='MIT',
     package_dir={
         'plyse': 'plyse',
         'plyse.expressions': 'plyse/expressions',


### PR DESCRIPTION
Agregué los campos de setup_requires e install_requires al setup.py. También cambié la versión por un string porque los imports del **init**.py llaman dependencias que todavía no están instaladas y eso rompe el setup con pip y setup.py.
