### PR TITLE
Pyparsing dropped python 3.2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: python
 python:
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 # command to install dependencies
 install: "pip install -r requirements.txt"
 # command to run tests
-script: 
+script:
   - py.test -v --color=yes

--- a/plyse/__init__.py
+++ b/plyse/__init__.py
@@ -6,4 +6,4 @@ from .expressions.primitives import *
 from .expressions.terms import *
 
 
-__version__ = '1.0.2'
+__version__ = '1.0.3'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pyparsing
+pyparsing==2.3.1

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     },
     packages=['plyse', 'plyse.expressions', 'plyse.tests'],
     test_suite='tests',
+    python_requires='>=2.6, !=3.0.*, !=3.1.*, !=3.2.*',
     keywords="search query parser lucene gmail syntax grammar",
     classifiers=[
         'Development Status :: 5 - Production/Stable',
@@ -42,10 +43,10 @@ setup(
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.1',
-        'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 )


### PR DESCRIPTION
Python 3.1 and 3.2 are no longer supported, since plyse relies heavily on this package dropped support for plyse as well. Also fixed the version in the requirements.txt